### PR TITLE
Initialization and re-configure support fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,10 @@ This wrapper utilizes **uMMAP-IO** with certain default settings, while hiding t
 The implementation of **uMMAP-IO** contains the following known bugs and limitations:
 * **Unable to map, unmap, and map again.** See [Issue #1](https://github.com/sergiorg-kth/ummap-io/issues/1) for a fix.
 * **Integration as part of another library is not supported.** See [Issue #1](https://github.com/sergiorg-kth/ummap-io/issues/1) for a fix.
-* **Multi-threading is not supported.**
-* **I/O drivers are not supported.**
-* **Shared compute nodes are not supported.**
-* **Shared files with overlapping areas not supported.**
+* **Multi-threading is not supported.** Using the library with multiple threads can produce unexpected issues, even when accessing non-overlapping areas of a mapping.
+* **I/O drivers are not supported.** An I/O driver abstraction can provide benefits on certain file systems (e.g., MPI-IO collective operations for large process counts).
+* **Shared compute nodes are not supported.** Two different users running applications on a shared node can produce unexpected issues (i.e., **uMMAP-IO** calculates memory consumption assuming a single user).
+* **Shared files with overlapping areas not supported.** Consistency is not guaranteed when multiple processes `read` / `write` overlapping areas of a shared file.
 
 ## Disclaimer
 Even though the current `alpha` release of **uMMAP-IO** is relatively stable, we kindly ask you to report any issues that you might encounter on the [Issues](https://github.com/sergiorg-kth/ummap-io/issues) tab.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,6 @@ Pending.
 ## Source Code Example
 Pending.
 
-## Known Bugs
-Pending.
+## Known Limitations
+No multi-threaded or shared compute node support.
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ That is all!
 
 ## Simplified API
 
-A malloc-like interface is also available to use on the following repository:
+A `malloc`-like interface is also available to use on the following repository:
 
 https://github.com/sergiorg-kth/umalloc
 
@@ -55,9 +55,10 @@ This wrapper utilizes **uMMAP-IO** with certain default settings, while hiding t
 The implementation of **uMMAP-IO** contains the following known bugs and limitations:
 * **Unable to map, unmap, and map again.** See [Issue #1](https://github.com/sergiorg-kth/ummap-io/issues/1) for a fix.
 * **Integration as part of another library is not supported.** See [Issue #1](https://github.com/sergiorg-kth/ummap-io/issues/1) for a fix.
-* **Multi-threading is not supported.** A solution is not available yet, but we plan to work on it.
-* **I/O drivers are not supported.** A solution is not available yet, but we plan to work on it.
-* **Shared compute node not supported.** A solution is not available yet, but we plan to work on it.
+* **Multi-threading is not supported.**
+* **I/O drivers are not supported.**
+* **Shared compute nodes are not supported.**
+* **Shared files with overlapping areas not supported.**
 
 ## Disclaimer
 Even though the current `alpha` release of **uMMAP-IO** is relatively stable, we kindly ask you to report any issues that you might encounter on the [Issues](https://github.com/sergiorg-kth/ummap-io/issues) tab.

--- a/src/ummap.c
+++ b/src/ummap.c
@@ -823,7 +823,7 @@ int ummap(size_t size, size_t seg_size, int prot, int fd, off_t offset,
                            MUNMAP(addr, size);
                            if (ualloc != NULL)
                            {
-                               FREE(ualloc->policy);
+                               umpolicy_release(ualloc->policy);
                                FREE(ualloc->alloc_seg);
                            }
                            FREE(ualloc);

--- a/src/ummap.c
+++ b/src/ummap.c
@@ -759,7 +759,7 @@ int ummap(size_t size, size_t seg_size, int prot, int fd, off_t offset,
     char          *addr   = NULL;
     
     // Make sure that the segment size is correctly set
-    CHKB(((size % seg_size) || (seg_size < sysconf(_SC_PAGESIZE)) ||
+    CHKB((!seg_size || (size % seg_size) || seg_size < sysconf(_SC_PAGESIZE) ||
           (seg_size & ~(seg_size - 1)) != seg_size), EINVAL); // Power of 2
     
     // Configure the page-fault mechanism, if needed

--- a/src/ummap.c
+++ b/src/ummap.c
@@ -549,7 +549,7 @@ static int configure_pf_handler() __CHK_FN__
         
         str[0] = '\0'; // Reset the string
         CHK(get_env("UMMAP_BULK_SYNC", "%s", (void *)str));
-        g_status.bsync_enabled = !strcmp(str, "true");
+        g_status.bsync_enabled = (strcmp(str, "false") != 0);
         
         // Retrieve the main memory limit for all the allocations
         CHK(get_env("UMMAP_MEM_LIMIT", "%zu", (void *)&g_status.memlimit));

--- a/src/ummap_policy.c
+++ b/src/ummap_policy.c
@@ -135,7 +135,10 @@ int umpolicy_create(ummap_ptype_t ptype, ummap_policy_t **policy) __CHK_FN__
 void umpolicy_release(ummap_policy_t *policy)
 {
     // Remove all the dependencies from the segments and release the policy
-    clear_seg_list(&policy->list);
-    free(policy);
+    if (policy != NULL)
+    {
+        clear_seg_list(&policy->list);
+        free(policy);
+    }
 }
 

--- a/src/ummap_types.h
+++ b/src/ummap_types.h
@@ -115,13 +115,13 @@ typedef struct
     mconfig_t mconfig;             // Memory allocation configuration
     int32_t   bsync_enabled;       // Flag to enable bulk synchronization
     size_t    memlimit;            // Main memory limit for all the allocations
-    size_t    memlimit_rank;       // Main memory limit per rank (intra-node)
     uint32_t  r_index;             // Index of the rank (intra-node)
-    uint32_t  num_ranks_curr;      // Current-known number of ranks (intra-node)
-    int32_t   *ranks;              // Rank structure with the PIDs (intra-node)
     uint32_t  *num_ranks;          // Current number of ranks (intra-node)
-    uint64_t  *memsize;            // Process' memory consumption (intra-node)
-    uint64_t  **memsizes;          // Memory consumption structure (intra-node)
+    int32_t   *ranks;              // Rank structure with the PIDs (intra-node)
+    size_t    ranks_count;         // Size of rank structure, in num. elems.
+    size_t    *memsize;            // Process' memory consumption (intra-node)
+    size_t    **memsizes;          // Memory consumption structure (intra-node)
+    size_t    memsizes_count;      // Size of memsizes structure, in num. elems.
     sem_t     *sem;                // Synchronization semaphore
     uint32_t  num_reads;           // Number of I/O read operations
     uint32_t  num_writes;          // Number of I/O write operations

--- a/src/ummap_util.c
+++ b/src/ummap_util.c
@@ -9,10 +9,11 @@ typedef struct stat     stat_t;
 #define SHM_FPERM   (S_IRUSR | S_IWUSR)
 #define TIME_LIMIT  50000000LL // 50ms
 
-uint32_t log2s(uint32_t n)
+uint32_t log2s(uint64_t n)
 {
-    uint32_t logn  = (n >= (1 << 16)) * 16;
-    uint32_t limit = 16 + logn;
+    uint64_t factor = 16 + (n > UINT32_MAX) * 16;
+    uint64_t logn   = (n >= (1 << factor)) * factor;
+    uint64_t limit  = factor + logn;
     
     while ((n >> logn) > 1)
     {
@@ -24,7 +25,7 @@ uint32_t log2s(uint32_t n)
         logn--;
     }
     
-    return logn;
+    return (uint32_t)logn;
 }
 
 int ts_set(timespec_t *ts, time_t tv_sec, long tv_nsec) __CHK_FN__

--- a/src/ummap_util.c
+++ b/src/ummap_util.c
@@ -50,7 +50,7 @@ int get_totalram(size_t *totalram) __CHK_FN__
 int get_usedram(size_t *_usedram) __CHK_FN__
 {
     static int        fd       = -1;
-    static size_t     baseram  = UINT64_MAX;
+    // static size_t     baseram  = UINT64_MAX;
     static size_t     totalram = 0;
     static size_t     usedram  = 0;
     static off_t      offset   = 0;
@@ -96,12 +96,12 @@ int get_usedram(size_t *_usedram) __CHK_FN__
         usedram = totalram - (usedram << 10);
         
         // Cache the base reference RSS (i.e., assuming used at the beginning)
-        if (baseram == UINT64_MAX || (usedram < baseram))
-        {
-            baseram = usedram;
-        }
+        // if (baseram == UINT64_MAX || (usedram < baseram))
+        // {
+        //     baseram = usedram;
+        // }
         
-        usedram -= baseram;
+        // usedram -= baseram;
         
         CHK(clock_gettime(CLOCK_REALTIME, &ts[0]));
     }

--- a/src/ummap_util.c
+++ b/src/ummap_util.c
@@ -120,7 +120,8 @@ int get_env(const char *name, const char *format, void *target) __CHK_FN__
     return CHK_SUCCESS(CHK_EMPTY_ERROR_FN);
 }
 
-int open_shm(const char *name, size_t size, int8_t incr, void **addr) __CHK_FN__
+int open_shm(const char *name, size_t size, int8_t incr, void **addr,
+             size_t *count) __CHK_FN__
 {
     int32_t fd = -1;
     stat_t  st = { 0 };
@@ -137,6 +138,11 @@ int open_shm(const char *name, size_t size, int8_t incr, void **addr) __CHK_FN__
     *addr = mmap(NULL, st.st_size, (PROT_READ | PROT_WRITE), MAP_SHARED, fd, 0);
     CHKB((*addr == MAP_FAILED), ENOMEM);
     CHK(close(fd));
+    
+    if (size > 0 && count != NULL)
+    {
+        *count = st.st_size / size;
+    }
     
     return CHK_SUCCESS(CHK_EMPTY_ERROR_FN);
 }

--- a/src/ummap_util.h
+++ b/src/ummap_util.h
@@ -10,7 +10,7 @@ typedef struct timespec timespec_t;
 /**
  * Calculates the integer part of the base 2 logarithm of a given number.
  */
-uint32_t log2s(uint32_t n);
+uint32_t log2s(uint64_t n);
 
 /**
  * Defines a given time specification according to the current RTC time.

--- a/src/ummap_util.h
+++ b/src/ummap_util.h
@@ -35,7 +35,8 @@ int get_env(const char *name, const char *format, void *target);
 /**
  * Opens a shared memory segment and allows to extend it, if requested.
  */
-int open_shm(const char *str, size_t size, int8_t incr, void **addr);
+int open_shm(const char *str, size_t size, int8_t incr, void **addr,
+             size_t *count);
 
 /**
  * Opens a shared named semaphore with an initial value.


### PR DESCRIPTION
These changes add support to initialize uMMAP-IO without relying on a specific constructor. The main idea is that processes check the status of the PIDs available in the shared memory segment, and only consider "alive" those processes that are active and that started within a difference of maximum 250ms (i.e., on an HPC cluster, the processes are deployed almost simultaneously intra-node). In addition, most of the shared memory segments are now never removed, as they are supposed to be shared among executions.

On the other hand, these changes also help supporting releasing the page-fault mechanism and re-configuring it (solving the issue #1 reported by @svalat). Lastly, there are other minor changes and bug fixes as well.

**Important**: The initialization fix might incorrectly add at least one extra process if a PID available in the shared memory segment matches that of the process manager (e.g., Hydra). This is very unlikely, but it can happen. The only consequence is worse performance when going out-of-core due to the extra fake processes (i.e., the overall memory limit per rank is reduced, as there are extra processes). 